### PR TITLE
Use Tailwind's `resolveConfig` helper to load the final merged/resolved config

### DIFF
--- a/css-props-generator.js
+++ b/css-props-generator.js
@@ -1,6 +1,9 @@
 const fs = require('fs');
 const prettier = require('prettier');
-const config = require('./tailwind.config.js');
+const resolveConfig = require('tailwindcss/resolveConfig');
+const tailwindConfig = require('./tailwind.config.js');
+
+const config = resolveConfig(tailwindConfig);
 
 /*
   Converts the tailwind config elements into custom props.


### PR DESCRIPTION
The [recommended way of loading Tailwind config programmatically](https://tailwindcss.com/docs/configuration#referencing-in-java-script) is to use the `resolveConfig` helper. The reason for this is that in most Tailwind setups, any custom `theme` config is merged with a [set of default config](https://github.com/tailwindlabs/tailwindcss/blob/master/stubs/defaultConfig.stub.js). If we just `require` the config file directly then we will have access to the custom `theme` config, but not to any of the default values.

I realised after [mentioning this to @hankchizljaw on Twitter](https://twitter.com/philw_/status/1488598068450807808) that this isn't as useful as I thought it might be for this repo as the prototype creates a set of config items completely from scratch by [providing an empty `presets` array](https://github.com/hankchizljaw/CUBE-with-tailwind/blob/main/tailwind.config.js#L3) in the Tailwind config, so there are no default values being used, just the values being explicitly set inside the Tailwind config file. 

Still, it doesn't hurt to load the config this way and it might be useful for others using this repo as an example, or if, in the future, a client removes the `presets` config item.  As an example, this would let them create custom properties for the `borderRadius` values provided by Tailwind's default theme, even if they didn't have a customised `borderRadius` object in their Tailwind config file's `theme` section.